### PR TITLE
Adding new variable to control version upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 - Support to global cluster
 - Support for monitoring features
 
+## [0.0.3] - 2024-03-05
+
+- Add support for major version upgrades.
+
+
 ## [0.0.2] - 2023-11-30
 
 - Add support for storage encryption.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_allow_major_version_upgrade"></a> [allow\_major\_version\_upgrade](#input\_allow\_major\_version\_upgrade) | Enable to allow major engine version upgrades when changing engine versions. | `bool` | `false` | no |
 | <a name="input_apply_changes_immediately"></a> [apply\_changes\_immediately](#input\_apply\_changes\_immediately) | Changes to an RDS Cluster can occur when you manually change a parameter, such as port, and are reflected in the next maintenance window. You can use the apply\_changes\_immediately flag to instruct the service to apply the change immediately. | `bool` | `true` | no |
 | <a name="input_aurora_security_group_id"></a> [aurora\_security\_group\_id](#input\_aurora\_security\_group\_id) | Security group id to be attached to the created database instances. It must be a preexisting security group id, with the firewall rules that will be applied to the created cluster. | `string` | n/a | yes |
 | <a name="input_auto_minor_version_upgrade"></a> [auto\_minor\_version\_upgrade](#input\_auto\_minor\_version\_upgrade) | Specifies whether minor engine upgrades are applied automatically to the DB cluster during the maintenance window. | `bool` | `true` | no |

--- a/rds.tf
+++ b/rds.tf
@@ -51,7 +51,8 @@ resource "aws_rds_cluster" "primary" {
   storage_encrypted                   = var.storage_encrypted
   deletion_protection                 = var.deletion_protection
   kms_key_id                          = var.create_kms_key ? aws_kms_key.cluster_storage_key[0].arn : null
-
+  allow_major_version_upgrade         = var.allow_major_version_upgrade
+  
   lifecycle {
     ignore_changes = [
       replication_source_identifier

--- a/rds.tf
+++ b/rds.tf
@@ -52,7 +52,6 @@ resource "aws_rds_cluster" "primary" {
   deletion_protection                 = var.deletion_protection
   kms_key_id                          = var.create_kms_key ? aws_kms_key.cluster_storage_key[0].arn : null
   allow_major_version_upgrade         = var.allow_major_version_upgrade
-  
   lifecycle {
     ignore_changes = [
       replication_source_identifier

--- a/variables.tf
+++ b/variables.tf
@@ -178,6 +178,12 @@ variable "auto_minor_version_upgrade" {
   default     = true
 }
 
+variable "allow_major_version_upgrade" {
+  type        = bool
+  description = "Enable to allow major engine version upgrades when changing engine versions."
+  default     = false
+}
+
 variable "monitoring_interval" {
   type        = number
   description = "The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB cluster."


### PR DESCRIPTION
# Pull Request

## What does this PR do?
When updating major postgres versions, aws api needs to receive a flag called `AllowMajorVersionUpgrade`. Currently, this property is not exposed to modules's clients, and this makes it impossible to upgrade to new major versions.


## Why is this PR being done?
When trying to update to a major version, terraform apply failed with the error bellow:
![image](https://github.com/madelabs/terraform-aws-rds-cluster/assets/70518849/beb27aed-f913-4251-8615-51a6e459cec4)


## Checklist - These are **not** mandatory

- [x] I have updated the README.md if there are new procedures or changes.
- [x] I have updated CHANGELOG.md with new changes. 
- [x] I have deployed this change in another project successfully.

## Optional: Additional Notes
