### PR TITLE
0.0.6 Adding default name for database on the secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 - Support to global cluster
 - Support for monitoring features
 
+## [0.0.6] - 2024-07-30
+
+- Fixing a bug, where the db_name is `null` on the secret when the caller doesn't specify a database to be created. In these cases, the default `postgres` value is going to be added.
+
 ## [0.0.5] - 2024-07-26
 
 - Adding the ability on the module to create the master user's password, so the caller can choose between providing a password through a Secrets Manager Secret, or let the module create it. 

--- a/locals.tf
+++ b/locals.tf
@@ -4,4 +4,6 @@ locals {
   logs_set = compact([
     var.enable_postgresql_log ? "postgresql" : ""
   ])
+  db_password = var.generate_password == true ? random_password.aurora_password[0].result : data.aws_secretsmanager_secret_version.aurora_password[0].secret_string
+  db_name     = aws_rds_cluster.primary.database_name == null ? "postgres" : aws_rds_cluster.primary.database_name
 }

--- a/secrets.tf
+++ b/secrets.tf
@@ -11,16 +11,11 @@ resource "aws_secretsmanager_secret_version" "aurora_access_data_version" {
     endpoint      = aws_rds_cluster.primary.endpoint,
     read_endpoint = aws_rds_cluster.primary.reader_endpoint,
     port          = var.db_port,
-    dbname        = var.database_name
+    dbname        = local.db_name
   })
-
 }
 
 data "aws_secretsmanager_secret_version" "aurora_password" {
   count     = var.generate_password == true ? 0 : 1
   secret_id = var.secret_id
-}
-
-locals {
-  db_password = var.generate_password == true ? random_password.aurora_password[0].result : data.aws_secretsmanager_secret_version.aurora_password[0].secret_string
 }


### PR DESCRIPTION
# Pull Request

## What does this PR do?
It is a fix, to add db_name to the created secret, even when the caller don't specifies a database name.
There will always be a database named postgres, and if the user doesn't specify a name, the default name will be shown in the secret.

## Why is this PR being done?
To fix a bug

## Checklist - These are **not** mandatory

- [ ] I have updated the README.md if there are new procedures or changes.
- [x] I have updated CHANGELOG.md with new changes. 
- [x] I have deployed this change in another project successfully.

## Optional: Additional Notes
