### PR TITLE
0.0.11 Removing special characteres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Support to global cluster
+## [0.0.11] - 2024-10-02
+
+- Removing special charactere from the generated password. Rds does not accept some special characteres, and this can cause errors depending on the generated password;
 
 ## [0.0.10] - 2024-09-20
 

--- a/random.tf
+++ b/random.tf
@@ -1,5 +1,5 @@
 resource "random_password" "aurora_password" {
   count   = var.generate_password == true ? 1 : 0
   length  = 10
-  special = true
+  special = false
 }


### PR DESCRIPTION
# Pull Request

## What does this PR do?
It removes special charactere from the generated password.
Although it can work most of time, some characteres are not accepted by RDS, and it can cause errors like this below 
![image](https://github.com/user-attachments/assets/c3ee3663-e52a-4f0c-871a-791ca4f42928)

## Why is this PR being done?
To avoid errors of unsupported charactere

## Checklist - These are **not** mandatory

- [x] I have updated the README.md if there are new procedures or changes.
- [x] I have updated CHANGELOG.md with new changes. 
- [ ] I have deployed this change in another project successfully.

## Optional: Additional Notes
